### PR TITLE
MNSTR-3198: Fixed header on find room screen

### DIFF
--- a/frontend/src/apps/device/views/find-room/index.js
+++ b/frontend/src/apps/device/views/find-room/index.js
@@ -26,6 +26,9 @@ const Header = styled(Section).attrs({ header: true })`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: fixed;
+  width: 100%;
+  z-index: 2;
 `;
 
 const BackButton = styled(Button)`
@@ -46,6 +49,7 @@ const PageTitle = styled.span`
 const Content = styled.div`
   flex-grow: 1;
   overflow-y: auto;
+  padding-top: 3.54rem;
 `;
 
 const LoaderWrapper = styled.div`


### PR DESCRIPTION
Changed .css for the header to make it fixed during scrolling
![roombelt-scrolling](https://user-images.githubusercontent.com/10534284/64023515-c4b03480-cb38-11e9-8895-86afb17751dc.gif)
