### PR TITLE
MNSTR-3199: Booked room should remain visible on find rooms screen

### DIFF
--- a/frontend/src/apps/device/store/store.js
+++ b/frontend/src/apps/device/store/store.js
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware } from "redux";
+import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import { createLogger } from "redux-logger";
 
@@ -6,8 +6,16 @@ import reducer from "../state/reducer";
 
 const logger = createLogger({ collapsed: true });
 
+const composeEnhancers =
+    typeof window === 'object' &&
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+        window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+            // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
+        }) : compose;
+
+
 export const makeStore = (initialState = null) => initialState ? 
-  createStore(reducer, initialState, applyMiddleware(thunk, logger)) : 
-  createStore(reducer, applyMiddleware(thunk, logger))
+  createStore(reducer, initialState, composeEnhancers(applyMiddleware(thunk, logger))) :
+  createStore(reducer, composeEnhancers(applyMiddleware(thunk, logger)));
   
 export default makeStore();

--- a/frontend/src/apps/device/views/find-room/CalendarRow.js
+++ b/frontend/src/apps/device/views/find-room/CalendarRow.js
@@ -29,7 +29,7 @@ const CustomButton = styled(Button)`
     display: inline-block;
     width: auto;
   }
-`
+`;
 
 const Header = styled.div`
   display: flex;

--- a/frontend/src/apps/device/views/find-room/index.js
+++ b/frontend/src/apps/device/views/find-room/index.js
@@ -6,9 +6,8 @@ import { deviceActions } from "apps/device/actions/actions";
 import {
   allCalendarsSelector,
   areAllCalendarsLoadedSelector,
-  fontSizeSelector,
-  isAmPmClockSelector,
-  timestampSelector
+  currentActionSourceSelector,
+  fontSizeSelector
 } from "apps/device/selectors/selectors";
 
 import CalendarRow from "./CalendarRow";
@@ -60,9 +59,8 @@ const AllCalendarsView = ({
   calendars,
   areAllCalendarsLoaded,
   markUserActivity,
-  timestamp,
-  isAmPmClock,
-  fontSize
+  fontSize,
+  currentActionSource
 }) => {
   return (
     <Layout style={{ minHeight: "100%", height: "auto" }} flexbox fontSize={fontSize}>
@@ -79,22 +77,22 @@ const AllCalendarsView = ({
         )}
         {calendars
           .slice()
-          .sort(sortCalendars)
+          .sort(getCalendarsComparator(currentActionSource))
           .map(calendar => <CalendarRow key={calendar.id} calendarId={calendar.id} />)}
       </Content>
     </Layout>
   );
 };
 
-const sortCalendars = (calendar1, calendar2) => {
+const getCalendarsComparator = currentActionSource => (calendar1, calendar2) => {
   const now = Date.now();
 
   const event1 = calendar1.events[0];
   const event2 = calendar2.events[0];
 
-  if (!event1) {
+  if (!event1 || calendarIsActionSource(calendar1, currentActionSource)) {
     return -1;
-  } else if (!event2) {
+  } else if (!event2 || calendarIsActionSource(calendar2, currentActionSource)) {
     return 1;
   }
 
@@ -107,12 +105,13 @@ const sortCalendars = (calendar1, calendar2) => {
   } else return event2.startTimestamp - event1.startTimestamp;
 };
 
+const calendarIsActionSource = (calendar, actionSource) => actionSource && actionSource.startsWith(calendar.id);
+
 const mapStateToProps = state => ({
   areAllCalendarsLoaded: areAllCalendarsLoadedSelector(state),
   calendars: allCalendarsSelector(state),
-  timestamp: timestampSelector(state),
-  isAmPmClock: isAmPmClockSelector(state),
-  fontSize: fontSizeSelector(state)
+  fontSize: fontSizeSelector(state),
+  currentActionSource: currentActionSourceSelector(state)
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Changed sorting mechanism to ignore the state change of a room which has
just been booked in "Find Rooms" screen.
![roombelt-find-other](https://user-images.githubusercontent.com/10534284/64029888-c03e4880-cb45-11e9-956e-74ccea7089a7.gif)
